### PR TITLE
BIGINT should be mapped to Long

### DIFF
--- a/sql-importer-lib/src/main/java/com/couchbase/util/SqlImporter.java
+++ b/sql-importer-lib/src/main/java/com/couchbase/util/SqlImporter.java
@@ -236,7 +236,7 @@ public class SqlImporter {
                     if (rsmd.getColumnType(i) == java.sql.Types.ARRAY) {
                         map.put(columnName, rs.getArray(columnName));
                     } else if (rsmd.getColumnType(i) == java.sql.Types.BIGINT) {
-                        map.put(columnName, rs.getInt(columnName));
+                        map.put(columnName, rs.getLong(columnName));
                     } else if (rsmd.getColumnType(i) == java.sql.Types.BOOLEAN) {
                         map.put(columnName, rs.getBoolean(columnName));
                     } else if (rsmd.getColumnType(i) == java.sql.Types.BLOB) {


### PR DESCRIPTION
getInt occasionally throws errors like "'1.0E10' in column '9' is outside valid range for the datatype INTEGER."